### PR TITLE
add estatiticas on playerfootyevent

### DIFF
--- a/prisma/migrations/20230916162758_estatisticas/migration.sql
+++ b/prisma/migrations/20230916162758_estatisticas/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "player_footy_event" ADD COLUMN "victories" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,6 +74,7 @@ model PlayerFootyEvent {
   team_id        String
   goals          Int?
   assists        Int?
+  victories      Int?
   team           Team       @relation(fields: [team_id], references: [id])
   footyEvent     FootyEvent @relation(fields: [footy_event_id], references: [id])
   player         Player     @relation(fields: [player_id], references: [id])

--- a/src/repositories/playerFootyEvent.ts
+++ b/src/repositories/playerFootyEvent.ts
@@ -31,6 +31,31 @@ class PlayerFootyEventRepository {
         const playerFootyEvents = await prisma.playerFootyEvent.findMany();
         return playerFootyEvents;
     }
+
+    async addGoals(footy_event_id: string, player_id: string, goals: number): Promise<PlayerFootyEvent> {
+        const playerFootyEvent = await prisma.playerFootyEvent.update({
+            where: { footy_event_id_player_id: { footy_event_id, player_id } },
+            data: { goals: { increment: goals } }, // Incrementa o número de gols
+        });
+        return playerFootyEvent;
+    }
+
+    async addAssists(footy_event_id: string, player_id: string, assists: number): Promise<PlayerFootyEvent> {
+        const playerFootyEvent = await prisma.playerFootyEvent.update({
+            where: { footy_event_id_player_id: { footy_event_id, player_id } },
+            data: { assists: { increment: assists } }, // Incrementa o número de assistências
+        });
+        return playerFootyEvent;
+    }
+
+    async addVictory(footy_event_id: string, player_id: string, team_id: string): Promise<PlayerFootyEvent> {
+        const playerFootyEvent = await prisma.playerFootyEvent.update({
+            where: { footy_event_id_player_id: { footy_event_id, player_id } },
+            data: { victories: { increment: 1 } }, // Incrementa o número de vitórias
+        });
+        return playerFootyEvent;
+    }
 }
+
 
 export default new PlayerFootyEventRepository();


### PR DESCRIPTION
## O que eu fiz

- O que fiz
Adição de funções para incremento das estatíticas em um evento de pelada: gols, assistências e vitórias. As funções estão presentes no repositório "playerFootyEvent".
Fiz também a inserção de uma coluna "victories" na tabela de "PlayerFootyEvent"

## Como testar

1. No terminal:
   1. `gi fetch`
   1. `git checkout <branch_name>`
   1. `yarn install`
   1. `sudo docker-compose up`
   1. `yarn test`
2. No navegador abrir http://localhost:3001/<route>

3. Teste os requests no Insomnia
